### PR TITLE
Adding Brave to list of search engines

### DIFF
--- a/refinery-core/src/main/java/org/wikimedia/analytics/refinery/core/SearchEngine.java
+++ b/refinery-core/src/main/java/org/wikimedia/analytics/refinery/core/SearchEngine.java
@@ -29,6 +29,7 @@ public enum SearchEngine {
     BING("Bing", "\\.bing\\.", ""),
     YANDEX("Yandex", "yandex\\.", ""),
     BAIDU("Baidu", "\\.baidu\\.", ""),
+    BRAVE("Brave", "search\\.brave\\.", ""),
     DDG("DuckDuckGo", "duckduckgo\\.", ""),
     ECOSIA("Ecosia", "\\.ecosia\\.", ""),
     STARTPAGE("Startpage", "\\.(startpage|ixquick)\\.", ""),


### PR DESCRIPTION
Brave Search is available at [https://search.brave.com/](https://search.brave.com/).

This PR attempts to add Brave Search to the list of known search engines. In the event more changes are needed to add an entry, please feel free to drop this PR in favor of another one.

Many thanks for your work.